### PR TITLE
Added export metrics for upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ The **kubeforward** plugin is particularly useful for organizing a node-local-dn
      ```
    - Add the **kubeforward** plugin to the `plugin.cfg` file:
      ```text
-     kubeforward:github.com/yourusername/kubeforward
+     kubeforward:github.com/deckhouse/coredns-kubeforward
      ```
      Ensure that this line is added before the `forward:forward` line to maintain the correct order of plugin execution.
 
 2. **Build CoreDNS with the New Plugin**:
    - Execute the following commands:
      ```bash
-     go get github.com/Paramoshka/kubeforward
+     go get github.com/deckhouse/coredns-kubeforward
      go generate
      go build
      ```

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,20 @@
+package kubeforward
+
+import (
+	"github.com/coredns/coredns/plugin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"sync"
+)
+
+var (
+	RequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "kubeforward",
+		Name:      "request_duration_seconds",
+		Help:      "Histogram of DNS request duration in kubeforward, in seconds",
+		Buckets:   prometheus.ExponentialBuckets(0.01, 2, 10),
+	}, []string{"qtype", "rcode"})
+)
+
+var once sync.Once

--- a/setup.go
+++ b/setup.go
@@ -13,7 +13,7 @@ func init() { plugin.Register("kubeforward", setup) }
 
 func setup(c *caddy.Controller) error {
 
-	version := "0.3.5"
+	version := "0.4.0"
 
 	log.Printf("\033[34m[kubeforward] version: %s\033[0m\n", version)
 


### PR DESCRIPTION
Expose request_duration_seconds metric in kubeforward to observe latency of DNS requests to upstream servers.