### PR TITLE
[chore] implement upstream healthchecks option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ The plugin is configured in the `Corefile` as follows:
         service_name kube-dns
         port_name dns
         expire 10m
-        health_check 5s
+        upstream_read_timeout 5s
+        health_check no_rec domain example.org
         prefer_udp
         force_tcp
         slow_threshold 300ms
@@ -70,7 +71,13 @@ The plugin is configured in the `Corefile` as follows:
 
 - `expire`: Time after which cached connections expire. Default is 10s.
 
-- `health_check`: Interval for health checking of upstream servers. Default is 300s.
+- `upstream_read_timeout`: Read timeout for forwarded DNS requests to upstream endpoints. Default is 300s.
+
+- `health_check [no_rec] [domain FQDN]`: Partial health check configuration. `kubeforward` supports:
+  - `no_rec`: send health check queries with `RD=false`
+  - `domain FQDN`: override the queried domain for health checks
+
+  `kubeforward` does not support configuring the health check interval because the underlying `forward` plugin does not expose this setting through a public API. The interval remains the `forward` default of 500ms.
 
 - `force_tcp`: Forces the use of TCP for forwarding queries.
 

--- a/kubeforward.go
+++ b/kubeforward.go
@@ -28,7 +28,6 @@ type KubeForward struct {
 }
 
 func (df *KubeForward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-
 	df.cond.L.Lock()
 	if df.forwarder == nil {
 		df.cond.Wait()
@@ -104,7 +103,14 @@ func (df *KubeForward) UpdateForwardServers(newServers []string, config KubeForw
 	for _, server := range newServers {
 		proxyInstance := proxy.NewProxy(server, server, transport.DNS)
 		proxyInstance.SetExpire(config.Expire)
-		proxyInstance.SetReadTimeout(config.HealthCheck)
+		proxyInstance.SetReadTimeout(config.UpstreamReadTimeout)
+		// forward.SetProxyOptions stores opts on the forwarder, but does not
+		// propagate healthcheck settings to already created proxies.
+		proxyInstance.GetHealthchecker().SetDomain(config.opts.HCDomain)
+		proxyInstance.GetHealthchecker().SetRecursionDesired(config.opts.HCRecursionDesired)
+		if config.opts.ForceTCP {
+			proxyInstance.GetHealthchecker().SetTCPTransport()
+		}
 		newForwarder.SetProxy(proxyInstance)
 		newForwarder.SetProxyOptions(df.options)
 	}

--- a/setup.go
+++ b/setup.go
@@ -13,8 +13,7 @@ import (
 func init() { plugin.Register("kubeforward", setup) }
 
 func setup(c *caddy.Controller) error {
-
-	version := "0.4.1"
+	version := "0.5.0"
 
 	log.Printf("\033[34m[kubeforward] version: %s\033[0m\n", version)
 
@@ -26,7 +25,7 @@ func setup(c *caddy.Controller) error {
 
 	kubeForwardPlugin := &KubeForward{
 		Namespace:      config.Namespace,
-		ServiceName:    config.ServiceName, //kubernetes.io/service-name=d8-kube-dns
+		ServiceName:    config.ServiceName, // kubernetes.io/service-name=d8-kube-dns
 		forwarder:      nil,
 		options:        config.opts,
 		cond:           sync.NewCond(&sync.Mutex{}),
@@ -51,7 +50,6 @@ func setup(c *caddy.Controller) error {
 				kubeForwardPlugin.UpdateForwardServers(newServers, *config)
 				log.Printf("[kubeforward] Updated servers namespace%s, service_name=%s\n: %v", config.Namespace, config.ServiceName, newServers)
 			})
-
 			if err != nil {
 				log.Printf("[kubeforward] Error starting EndpointSlice watcher with label kubernetes.io/service-name=%s: %v", config.ServiceName, err)
 			}

--- a/utils.go
+++ b/utils.go
@@ -5,27 +5,29 @@ import (
 	"time"
 
 	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/proxy"
+	"github.com/miekg/dns"
 )
 
 type KubeForwardConfig struct {
-	Namespace      string
-	ServiceName    string
-	PortName       string
-	Expire         time.Duration
-	HealthCheck    time.Duration
-	SlowThreshold  time.Duration
-	SlowLogEnabled bool
-	opts           proxy.Options
+	Namespace           string
+	ServiceName         string
+	PortName            string
+	Expire              time.Duration
+	UpstreamReadTimeout time.Duration
+	SlowThreshold       time.Duration
+	SlowLogEnabled      bool
+	opts                proxy.Options
 }
 
 // ParseConfig parse conf CoreFile
 func ParseConfig(c *caddy.Controller) (*KubeForwardConfig, error) {
 	config := &KubeForwardConfig{
-		Expire:         10 * time.Second,  // Default value
-		HealthCheck:    300 * time.Second, // Default value
-		SlowThreshold:  0,
-		SlowLogEnabled: false,
+		Expire:              10 * time.Second,  // Default value
+		UpstreamReadTimeout: 300 * time.Second, // Default value
+		SlowThreshold:       0,
+		SlowLogEnabled:      false,
 		opts: proxy.Options{
 			ForceTCP:           false,
 			PreferUDP:          false,
@@ -66,11 +68,40 @@ func ParseConfig(c *caddy.Controller) (*KubeForwardConfig, error) {
 			if !c.NextArg() {
 				return nil, c.ArgErr()
 			}
+			for {
+				val := c.Val()
+				switch val {
+				case "no_rec":
+					config.opts.HCRecursionDesired = false
+				case "domain":
+					if !c.NextArg() {
+						return nil, c.ArgErr()
+					}
+					hcDomain := c.Val()
+					if _, ok := dns.IsDomainName(hcDomain); !ok {
+						return nil, fmt.Errorf("health_check: invalid domain name %s", hcDomain)
+					}
+					config.opts.HCDomain = plugin.Name(hcDomain).Normalize()
+				default:
+					if _, err := time.ParseDuration(val); err == nil {
+						return nil, fmt.Errorf("health_check duration is not supported by kubeforward; use upstream_read_timeout")
+					}
+					return nil, fmt.Errorf("health_check: unknown option %s", val)
+				}
+				if !c.NextArg() {
+					break
+				}
+			}
+
+		case "upstream_read_timeout":
+			if !c.NextArg() {
+				return nil, c.ArgErr()
+			}
 			duration, err := time.ParseDuration(c.Val())
 			if err != nil {
-				return nil, fmt.Errorf("invalid health_check duration: %v", err)
+				return nil, fmt.Errorf("invalid upstream_read_timeout duration: %v", err)
 			}
-			config.HealthCheck = duration
+			config.UpstreamReadTimeout = duration
 		case "slow_threshold":
 			if !c.NextArg() {
 				return nil, c.ArgErr()

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,9 +1,12 @@
 package kubeforward
 
 import (
-	"github.com/coredns/caddy"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/coredns/caddy"
+	"github.com/coredns/coredns/plugin/pkg/proxy"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -15,41 +18,47 @@ func TestParseConfig(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name: "Valid config with all parameters",
-			input: `dynamicforward {
+			name: "Valid config with all supported parameters",
+			input: `kubeforward {
 				namespace kube-system
 				service_name d8-kube-dns
 				port_name dns
 				expire 10m
-				health_check 5s
+				upstream_read_timeout 5s
+				health_check no_rec domain example.org
+				prefer_udp
 				slow_threshold 200ms
 				slow_log
 			}`,
 			expected: KubeForwardConfig{
-				Namespace:      "kube-system",
-				ServiceName:    "d8-kube-dns",
-				PortName:       "dns",
-				Expire:         10 * time.Minute,
-				HealthCheck:    5 * time.Second,
-				SlowThreshold:  200 * time.Millisecond,
-				SlowLogEnabled: true,
+				Namespace:           "kube-system",
+				ServiceName:         "d8-kube-dns",
+				PortName:            "dns",
+				Expire:              10 * time.Minute,
+				UpstreamReadTimeout: 5 * time.Second,
+				SlowThreshold:       200 * time.Millisecond,
+				SlowLogEnabled:      true,
+				opts: proxy.Options{
+					PreferUDP:          true,
+					HCRecursionDesired: false,
+					HCDomain:           "example.org.",
+				},
 			},
 			expectErr: false,
 		},
 		{
 			name: "Config missing namespace",
-			input: `dynamicforward {
+			input: `kubeforward {
 				service_name d8-kube-dns
 				port_name dns
-				expire 10m
-				health_check 5s
+				upstream_read_timeout 5s
 			}`,
 			expectErr:     true,
 			expectedError: "namespace, servicename, and portname are required parameters",
 		},
 		{
 			name: "Config with invalid expire value",
-			input: `dynamicforward {
+			input: `kubeforward {
 				namespace kube-system
 				service_name d8-kube-dns
 				port_name dns
@@ -60,68 +69,78 @@ func TestParseConfig(t *testing.T) {
 		},
 		{
 			name: "Config with missing health_check value",
-			input: `dynamicforward {
+			input: `kubeforward {
 				namespace kube-system
 				service_name d8-kube-dns
 				port_name dns
-				health_check 
+				health_check
 			}`,
 			expectErr:     true,
-			expectedError: "wrong argument count or unexpected line ending",
+			expectedError: "Wrong argument count or unexpected line ending after 'health_check'",
+		},
+		{
+			name: "Config with unsupported health_check duration",
+			input: `kubeforward {
+				namespace kube-system
+				service_name d8-kube-dns
+				port_name dns
+				health_check 500ms
+			}`,
+			expectErr:     true,
+			expectedError: "health_check duration is not supported by kubeforward; use upstream_read_timeout",
+		},
+		{
+			name: "Config with invalid health_check domain",
+			input: `kubeforward {
+				namespace kube-system
+				service_name d8-kube-dns
+				port_name dns
+				health_check domain example..org
+			}`,
+			expectErr:     true,
+			expectedError: "health_check: invalid domain name",
 		},
 		{
 			name: "Minimal valid config",
-			input: `dynamicforward {
+			input: `kubeforward {
 				namespace kube-system
 				service_name d8-kube-dns
 				port_name dns
 			}`,
 			expected: KubeForwardConfig{
-				Namespace:      "kube-system",
-				ServiceName:    "d8-kube-dns",
-				PortName:       "dns",
-				Expire:         30 * time.Minute,
-				HealthCheck:    10 * time.Second,
-				SlowThreshold:  0,
-				SlowLogEnabled: false,
+				Namespace:           "kube-system",
+				ServiceName:         "d8-kube-dns",
+				PortName:            "dns",
+				Expire:              10 * time.Second,
+				UpstreamReadTimeout: 300 * time.Second,
+				SlowThreshold:       0,
+				SlowLogEnabled:      false,
+				opts: proxy.Options{
+					HCRecursionDesired: true,
+					HCDomain:           ".",
+				},
 			},
 			expectErr: false,
 		},
 		{
-			name: "Config with slow_threshold",
-			input: `dynamicforward {
+			name: "Config with force_tcp",
+			input: `kubeforward {
 				namespace kube-system
 				service_name d8-kube-dns
 				port_name dns
-				slow_threshold 150ms
+				force_tcp
 			}`,
 			expected: KubeForwardConfig{
-				Namespace:      "kube-system",
-				ServiceName:    "d8-kube-dns",
-				PortName:       "dns",
-				Expire:         30 * time.Minute,
-				HealthCheck:    10 * time.Second,
-				SlowThreshold:  150 * time.Millisecond,
-				SlowLogEnabled: false,
-			},
-			expectErr: false,
-		},
-		{
-			name: "Config with slow_log enabled",
-			input: `dynamicforward {
-				namespace kube-system
-				service_name d8-kube-dns
-				port_name dns
-				slow_log
-			}`,
-			expected: KubeForwardConfig{
-				Namespace:      "kube-system",
-				ServiceName:    "d8-kube-dns",
-				PortName:       "dns",
-				Expire:         30 * time.Minute,
-				HealthCheck:    10 * time.Second,
-				SlowThreshold:  0,
-				SlowLogEnabled: true,
+				Namespace:           "kube-system",
+				ServiceName:         "d8-kube-dns",
+				PortName:            "dns",
+				Expire:              10 * time.Second,
+				UpstreamReadTimeout: 300 * time.Second,
+				opts: proxy.Options{
+					ForceTCP:           true,
+					HCRecursionDesired: true,
+					HCDomain:           ".",
+				},
 			},
 			expectErr: false,
 		},
@@ -129,18 +148,15 @@ func TestParseConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// Parsing controller
 			controller := caddy.NewTestController("dns", test.input)
 
-			// Parse config
 			config, err := ParseConfig(controller)
 
-			// Check err
 			if test.expectErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
 				}
-				if !containsError(err.Error(), test.expectedError) {
+				if !strings.Contains(err.Error(), test.expectedError) {
 					t.Fatalf("expected error containing %q, got %q", test.expectedError, err.Error())
 				}
 				return
@@ -150,21 +166,20 @@ func TestParseConfig(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			// Compare results
 			if config.Namespace != test.expected.Namespace {
 				t.Errorf("expected namespace %q, got %q", test.expected.Namespace, config.Namespace)
 			}
 			if config.ServiceName != test.expected.ServiceName {
-				t.Errorf("expected label %q, got %q", test.expected.ServiceName, config.ServiceName)
+				t.Errorf("expected service_name %q, got %q", test.expected.ServiceName, config.ServiceName)
 			}
 			if config.PortName != test.expected.PortName {
-				t.Errorf("expected portname %q, got %q", test.expected.PortName, config.PortName)
+				t.Errorf("expected port_name %q, got %q", test.expected.PortName, config.PortName)
 			}
 			if config.Expire != test.expected.Expire {
 				t.Errorf("expected expire %v, got %v", test.expected.Expire, config.Expire)
 			}
-			if config.HealthCheck != test.expected.HealthCheck {
-				t.Errorf("expected health_check %v, got %v", test.expected.HealthCheck, config.HealthCheck)
+			if config.UpstreamReadTimeout != test.expected.UpstreamReadTimeout {
+				t.Errorf("expected upstream_read_timeout %v, got %v", test.expected.UpstreamReadTimeout, config.UpstreamReadTimeout)
 			}
 			if config.SlowThreshold != test.expected.SlowThreshold {
 				t.Errorf("expected slow_threshold %v, got %v", test.expected.SlowThreshold, config.SlowThreshold)
@@ -172,11 +187,18 @@ func TestParseConfig(t *testing.T) {
 			if config.SlowLogEnabled != test.expected.SlowLogEnabled {
 				t.Errorf("expected slow_log %v, got %v", test.expected.SlowLogEnabled, config.SlowLogEnabled)
 			}
+			if config.opts.HCRecursionDesired != test.expected.opts.HCRecursionDesired {
+				t.Errorf("expected health_check recursion_desired %v, got %v", test.expected.opts.HCRecursionDesired, config.opts.HCRecursionDesired)
+			}
+			if config.opts.HCDomain != test.expected.opts.HCDomain {
+				t.Errorf("expected health_check domain %q, got %q", test.expected.opts.HCDomain, config.opts.HCDomain)
+			}
+			if config.opts.ForceTCP != test.expected.opts.ForceTCP {
+				t.Errorf("expected force_tcp %v, got %v", test.expected.opts.ForceTCP, config.opts.ForceTCP)
+			}
+			if config.opts.PreferUDP != test.expected.opts.PreferUDP {
+				t.Errorf("expected prefer_udp %v, got %v", test.expected.opts.PreferUDP, config.opts.PreferUDP)
+			}
 		})
 	}
-}
-
-// containsError
-func containsError(actual, expected string) bool {
-	return len(actual) >= len(expected) && actual[:len(expected)] == expected
 }


### PR DESCRIPTION
Updated `kubeforward` to support `forward` health check options honestly and partially: `health_check` now supports only `no_rec` and `domain FQDN`, while request timeout was renamed to explicit `upstream_read_timeout`. 